### PR TITLE
Use prop-types package instead of directly accessing React.PropTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react": "^0.14.0 || ^15.0.0"
   },
   "dependencies": {
+    "prop-types": "^15.5.10",
     "sanitize-html": "^1.11.1"
   },
   "standard": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
-import React, { Component, PropTypes, createElement } from 'react'
+import React, { Component, createElement } from 'react'
+import PropTypes from 'prop-types'
 import sanitizeHtml from 'sanitize-html'
 
 export default class SimpleFormat extends Component {
   static propTypes = {
     text: PropTypes.string.isRequired,
     wrapperTag: PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+      PropTypes.string,
+      PropTypes.object
     ]),
     wrapperTagProps: PropTypes.object,
     postfix: PropTypes.node


### PR DESCRIPTION
Earlier this year, `React.PropTypes` [was deprecated](https://github.com/facebook/react/blob/master/CHANGELOG.md#1550-april-7-2017) and extracted to the `prop-types` package