### PR TITLE
Update PropTypes dependency

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
-import React, { Component, PropTypes, createElement } from 'react'
+import React, { Component, createElement } from 'react'
+import PropTypes from 'prop-types'
 import sanitizeHtml from 'sanitize-html'
 
 export default class SimpleFormat extends Component {
   static propTypes = {
     text: PropTypes.string.isRequired,
     wrapperTag: PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.object
+      PropTypes.string,
+      PropTypes.object
     ]),
     wrapperTagProps: PropTypes.object,
     postfix: PropTypes.node


### PR DESCRIPTION
This should fix https://github.com/rilkevb/react-simple-format/issues/11. 

I'm new to React so my guess is that this is using an old way of handling proptypes (through `react`), since `React.PropTypes` is `undefined`. After copying this component into my app manually, I had to make the following changes to get it working. 

Figured I might as well open a PR for anyone else having the same problem.